### PR TITLE
Task 855214: To add the Colorpicker documentation, if the noColor property is set to true, we need to ensure that the modeswitcher property is set to false.

### DIFF
--- a/ej2-javascript/color-picker/how-to/handle-no-color-support.md
+++ b/ej2-javascript/color-picker/how-to/handle-no-color-support.md
@@ -52,7 +52,7 @@ In the following sample, the first tile of the color palette represents the no c
 {% previewsample "page.domainurl/code-snippet/colorpicker/no-color/default-cs1" %}
 {% endif %}
 
->if the noColor property is set to true, ensure that the modeswitcher property is set to false.
+>If the [`noColor`](../../api/color-picker/#nocolor) property is enabled, make sure to disable the [`modeswitcher`](../../api/color-picker/#modeswitcher) property.
 
 ## Custom no color
 

--- a/ej2-javascript/color-picker/how-to/handle-no-color-support.md
+++ b/ej2-javascript/color-picker/how-to/handle-no-color-support.md
@@ -52,6 +52,8 @@ In the following sample, the first tile of the color palette represents the no c
 {% previewsample "page.domainurl/code-snippet/colorpicker/no-color/default-cs1" %}
 {% endif %}
 
+>if the noColor property is set to true, ensure that the modeswitcher property is set to false.
+
 ## Custom no color
 
 The following sample show the color palette with custom no color option.


### PR DESCRIPTION
### Bug description

To add the Colorpicker documentation, if the noColor property is set to true, we need to ensure that the modeswitcher property is set to

### Root cause

NA

#### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.
- [x] Guidelines/documents are not followed
- [ ] Common guidelines / Core team guideline
- [ ] Specification document
- [ ] Requirement document

### Action taken:

Added in color picker documentation to ensure mode switcher property is false when no color property is set to true

### Related areas:

UG documentation

### Is it a breaking issue?

no

### Solution description

Added in color picker documentation to ensure mode switcher property is false when no color property is set to true

### Areas affected and ensured

Color picker ug documentation
